### PR TITLE
Fix setting and clearing env in the wrong order

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -350,12 +350,13 @@ fn create_process(task: &Task) -> Result<Child> {
         .current_dir(working_dir)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .envs(&task.env);
+        .stderr(Stdio::inherit());
 
     if task.clear_env {
         child.env_clear();
     }
+
+    child.envs(&task.env);
 
     Ok(child.spawn()?)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -506,7 +506,7 @@ fn draw_tasks(group: &Group) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::env::{set_var};
+    use std::env::{remove_var, set_var};
     use super::*;
 
     #[test]
@@ -566,6 +566,8 @@ mod tests {
 
         let output = create_process(&task, false).unwrap().wait_with_output().unwrap();
 
+        remove_var("GLOBAL_VAR_123");
+
         assert_eq!("The value of FOO is bar and GLOBAL_VAR_123 is present", String::from_utf8_lossy(&output.stdout));
     }
 
@@ -585,6 +587,8 @@ mod tests {
         let task: Task = serde_yaml::from_str(yaml).unwrap();
 
         let output = create_process(&task, false).unwrap().wait_with_output().unwrap();
+
+        remove_var("GLOBAL_VAR_234");
 
         assert_eq!("The value of FOO is bar and GLOBAL_VAR_234 is ", String::from_utf8_lossy(&output.stdout));
     }


### PR DESCRIPTION
Thanks for the quick acceptance of my previous change 🙏 

While refactoring/implementing the review feedback, I lost track of what I was doing, more specifically the fact that I was now first setting the env vars, and clearing them **after** 🤦 

This PR puts them back in the correct order, so the env vars actually work when setting `clear_env`.

