### PR TITLE
feat: Look for config in ~/.config/ttr/ttr.yaml

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ struct Opts {
 }
 
 const TTR_CONFIG: &str = ".ttr.yaml";
+const TTR_HOME_CONFIG: &str = "ttr.yaml";
 
 type Result<T> = anyhow::Result<T>;
 
@@ -356,9 +357,9 @@ fn read_tasks() -> Result<Vec<Group>> {
         tasks.push(tasks_from_file(config)?);
     }
 
-    // ~/.config/ttr/.ttr.yaml
+    // ~/.config/ttr/ttr.yaml
     let config_dir_config = dirs::config_dir()
-        .map(|home| home.join("ttr").join(TTR_CONFIG))
+        .map(|home| home.join("ttr").join(TTR_HOME_CONFIG))
         .filter(|config| config.is_file());
     if let Some(config) = config_dir_config {
         tasks.push(tasks_from_file(config)?);


### PR DESCRIPTION
I feel that the more natural filename would be `ttr.yaml` when looking in `~/.config/ttr`, rather than a hidden file `.ttr.yaml`

Fixes #24

## Examples

### Git
- Legacy: ~/.gitconfig
- XDG: ~/.config/git/config

### SSH
- Legacy: ~/.ssh/config
- XDG: ~/.config/ssh/config

### Alacritty (terminal emulator)
- Legacy: ~/.alacritty.yml
- XDG: ~/.config/alacritty/alacritty.yml

### MPV (media player)
- Legacy: ~/.mpv/config
- XDG: ~/.config/mpv/mpv.conf

### i3 / sway (tiling window managers)
- Legacy: ~/.i3/config
- XDG: ~/.config/i3/config or ~/.config/sway/config